### PR TITLE
Improve project build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,33 @@ Otherwise, you can download stable versions on F-Droid:
      alt="Get it on F-Droid"
      height="80">](https://f-droid.org/packages/com.graphhopper.maps/)
 
-## Build
+## Development
 
-Make sure you have all the [required dependencies](https://capacitorjs.com/docs/v2/getting-started/dependencies)
+### Clone the repository
+``` bash
+git clone --recursive https://github.com/boldtrn/graphhopper-maps-capacitor.git
+```
 
-Then run: `./build.sh`
+### Build the project
+Make sure you have all the [required dependencies for Capacitor](https://capacitorjs.com/docs/v2/getting-started/dependencies).
 
+``` bash
+./build.sh
+```
+
+### Run the project
 Note: you can either run the app straight away or open it in Android Studio. You can generate an APK in Android Studio,
 or debug the app etc.
 
-**Open Android App**
+#### Open Android App
+``` bash
+npx cap run android
+```
 
-`npx cap run android`
-
-**Open in Android Studio**
-
-`npx cap open android`
+#### Open in Android Studio
+``` bash
+npx cap open android
+```
 
 ## Release Update Version
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ apply from: "variables.gradle"
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ npm install
 npm run build
 
 # Create launch and splash icons
-cordova-res android --skip-config --copy
+npx cordova-res android --skip-config --copy
 
 npx cap sync
 


### PR DESCRIPTION
- add the recursive `git clone` command in the README to also fetch the required `graphhopper-maps` submodule
- call the local version of `cordova-res` in the `build.sh` to not require a global installation of this dependency
- use `mavenCentral()` instead of `jcenter()` for maven dependencies since [jcenter is deprecated](https://blog.gradle.org/jcenter-shutdown)