### PR TITLE
Draft: Add a build workflow that replaces the build.sh in the pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build the application
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Build node package
+        run: npm run build
+      - name: Create launch and splash icons
+        run: npx cordova-res android --skip-config --copy
+      - name: npx cap sync
+        run: npx cap sync
+      - name: Build the android app
+        working-directory: ./android
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
Currently the `build.sh` is called in the pipeline as part of the [generate-release workflow](https://github.com/boldtrn/graphhopper-maps-capacitor/blob/4e8976d6d68d9ebda35690b57464cddce305f130/.github/workflows/generate-release.yml).
It looks like as if a failure in the script is not recognized in the pipeline (as can be seen [in this pipeline run](https://github.com/boldtrn/graphhopper-maps-capacitor/runs/5201409190?check_suite_focus=true#step:3:211)).

To better use the capabilities of github pipelines and to better distinguish the individual steps that may fail, this introduces a `build` workflow that is not using the `build.sh`.

Note: This is currently a draft since I can only test the functionality when creating the pull request.
